### PR TITLE
Add test on clicking color picker selection

### DIFF
--- a/components/color-picker/components/color-picker-selection/test.js
+++ b/components/color-picker/components/color-picker-selection/test.js
@@ -1,0 +1,27 @@
+/* global test */
+const expect = require('chai').expect;
+
+test('color-picker-selection color', function (context) {
+  const output = context.render({
+    color: '#ff8080'
+  });
+
+  expect(output.$('div').attr('style')).to.contain('background-color:#ff8080');
+});
+
+test('color-picker-selection when clicked should emit colorSelected event', function (context) {
+  const output = context.render({
+    color: '#ff8080'
+  });
+
+  var component = output.component;
+  var isCalled = false;
+  component.on('colorSelected', function () {
+    isCalled = true;
+  });
+
+  var componentEl = component.el;
+  componentEl.click();
+
+  expect(isCalled).to.equal(true);
+});


### PR DESCRIPTION
I thought about adding a simple example on how to test widget behaviour, on top of testing the rendering result. This is a simple implementation which shows:

- how to get an component instance from marko-devtools' `context.render` result.
- how to simulate click event

I was wondering if we can use sinon for mocking/spying & make the code much nicer. I made another branch with sinon's spy: https://github.com/abiyasa/marko-color-picker/commit/b4e9c7c6f38fe17e1c450a5cae41dc9152d24139

What do you think?