### PR TITLE
Update to marko-cli

### DIFF
--- a/components/color-picker/components/color-picker-header/test.server.js
+++ b/components/color-picker/components/color-picker-header/test.server.js
@@ -1,5 +1,5 @@
 /* global test */
-const expect = require('chai').expect;
+const { expect } = require('chai');
 
 test('color-picker-header color', function (context) {
   const output = context.render({

--- a/components/color-picker/components/color-picker-selection/test.js
+++ b/components/color-picker/components/color-picker-selection/test.js
@@ -1,27 +1,25 @@
 /* global test */
-const expect = require('chai').expect;
+const { expect } = require('chai');
 
 test('color-picker-selection color', function (context) {
-  const output = context.render({
+  const { component } = context.render({
     color: '#ff8080'
   });
 
-  expect(output.$('div').attr('style')).to.contain('background-color:#ff8080');
+  expect(component.el.getAttribute('style')).to.contain('background-color:#ff8080');
 });
 
 test('color-picker-selection when clicked should emit colorSelected event', function (context) {
-  const output = context.render({
+  const { component } = context.render({
     color: '#ff8080'
   });
 
-  var component = output.component;
-  var isCalled = false;
+  let isCalled = false;
   component.on('colorSelected', function () {
     isCalled = true;
   });
 
-  var componentEl = component.el;
-  componentEl.click();
+  component.el.click();
 
   expect(isCalled).to.equal(true);
 });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.13.0",
     "eslint-config-marko": "^1.0.1",
-    "marko-devtools": "^1.0.2"
+    "marko-cli": "^2.2.0"
   },
   "dependencies": {
     "flat-colors": "^3.3.7",


### PR DESCRIPTION
Change marko-devtools to marko-cli. 

- Update test accordingly.
- Update syntax to ES6.

I have problem on `renderResult.$()` when it runs on browser. I got

```
1) components/color-picker/components/color-picker-header
       color-picker-header color:
     AssertionError: object tested must be an array, an object, or a string, but undefined given
      at Object.module.exports [as expectTypes] (static/browser-tests-runner/chai$3.5.0/lib/chai/utils/expectTypes.js:38:11)
      at Assertion.include (static/browser-tests-runner/chai$3.5.0/lib/chai/core/assertions.js:206:7)
      at Assertion.assert (static/browser-tests-runner/chai$3.5.0/lib/chai/utils/addChainableMethod.js:84:49)
      at Context.<anonymous> (static/browser-tests-runner/marko-color-picker$0.0.3/components/color-picker/components/color-picker-header/test.js:9:44)
      at Context.<anonymous> (static/browser-tests-runner/@marko/test$1.0.2/util/browser-tests-runner/setup.js:33:34)

```

However, it works when you run the test on the server, so I have to rename rendering test to `test.server.js`

To make the click testing work, I have to use `renderResult.component.el` which will get the DOM element of the component. Once I get the DOM, I can click it or assert the class list for the rendering test. Not sure if this is recommended pattern on using marko-cli?